### PR TITLE
fix(docker): move production builds to Node 24 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:24-alpine AS builder
 
 WORKDIR /workspace
 

--- a/Dockerfile.proxy
+++ b/Dockerfile.proxy
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- replace the EOL Node 20 Alpine builder image with Node 24 LTS
- replace the proxy runtime image with Node 24 LTS
- keep the runtime migration isolated from the http-proxy-middleware 4 migration

This is the human-owned replacement recommended in #113 and should land before #123. It supersedes the proposed Node 26 Current upgrade in #113.

## Verification
- `npm ci` on Node v24.15.0
- `npm test` (83 passed)
- `npm run test:e2e` (141 passed)
- `npm run build`
- built `Dockerfile` as `rum1n8-node24-app:test`
- built `Dockerfile.proxy` as `rum1n8-node24-proxy:test`
- smoke-tested app `/health` and `/` in a production-like Docker network
- smoke-tested proxy `/health`
- inspected both container logs; no Node engine or runtime warnings

## Notes
- npm reports two existing critical audit findings during the full app install; this PR does not alter dependencies
- the main image build retains the existing warning about `VITE_GOOGLE_CLIENT_SECRET` being passed as a build arg