### PR TITLE
fix(release): pin semantic-release to 25.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@tailwindcss/vite": "^4.3.0",
         "@vitejs/plugin-vue": "^6.0.7",
         "concurrently": "^9.2.1",
-        "semantic-release": "^25.0.4",
+        "semantic-release": "25.0.3",
         "tailwindcss": "^4.3.0",
         "vite": "^8.0.16",
         "vite-plugin-pwa": "^1.3.0",
@@ -11618,9 +11618,9 @@
       "license": "MIT"
     },
     "node_modules/semantic-release": {
-      "version": "25.0.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.4.tgz",
-      "integrity": "sha512-GeYqMPlv2BdLw/kNSjrDk8sl4yfc/sTE3szNP/X+1EXQpdhk7+oG5gEGh3tDk8onJm/oGaS6NWNEth9mGC0FGA==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.3.tgz",
+      "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@tailwindcss/vite": "^4.3.0",
     "@vitejs/plugin-vue": "^6.0.7",
     "concurrently": "^9.2.1",
-    "semantic-release": "^25.0.4",
+    "semantic-release": "25.0.3",
     "tailwindcss": "^4.3.0",
     "vite": "^8.0.16",
     "vite-plugin-pwa": "^1.3.0",


### PR DESCRIPTION
## Summary
- downgrade `semantic-release` from broken `25.0.4` to `25.0.3`
- pin the version exactly so fresh installs cannot float back to `25.0.4`
- retain the other dependency updates from #125

## Root cause
Both recent `main` deploys failed before image publishing because `semantic-release` 25.0.4 imports an unavailable `@semantic-release/core` package:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package `@semantic-release/core` imported from node_modules/semantic-release/index.js
```

This failure predates and is unrelated to the Node 24 Docker migration in #126.

## Verification
- `npm ci`
- direct `semantic-release` ESM import succeeds
- `npm run release -- --dry-run --no-ci` succeeds and loads all configured plugins
- `npm test` (83 passed)
- `npm run test:e2e` (141 passed)

Closes the release regression introduced by #125.